### PR TITLE
Fixed artifactId to match fabric8 configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>akka-java</groupId>
-    <artifactId>cluster-sharding-openshift</artifactId>
+    <artifactId>akka-cluster-openshift</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>


### PR DESCRIPTION
The fabric8 configuration is assuming that the built jar name is akka-cluster-openshift, not cluster-sharding-openshift, so I updated the artifactId accordingly.