### PR TITLE
Bind to all local IP addresses

### DIFF
--- a/src/main/java/cluster/sharding/HttpServerActor.java
+++ b/src/main/java/cluster/sharding/HttpServerActor.java
@@ -107,11 +107,9 @@ public class HttpServerActor extends AbstractLoggingActor {
 
         try {
             CompletionStage<ServerBinding> serverBindingCompletionStage = Http.get(actorSystem)
-                    .bindAndHandleSync(this::handleHttpRequest, ConnectHttp.toHost(InetAddress.getLocalHost().getHostName(), serverPort), actorMaterializer);
+                    .bindAndHandleSync(this::handleHttpRequest, ConnectHttp.toHost("0.0.0.0", serverPort), actorMaterializer);
 
             serverBindingCompletionStage.toCompletableFuture().get(15, TimeUnit.SECONDS);
-        } catch (UnknownHostException e) {
-            log().error(e, "Unable to access hostname");
         } catch (InterruptedException | TimeoutException | ExecutionException e) {
             log().error(e, "Monitor HTTP server error");
         } finally {


### PR DESCRIPTION
This binds the HTTP server to all local IP addresses (ie 0.0.0.0) rather than just the pods IP address. This is necessary when deploying to Istio, since Envoy will connect on 127.0.0.1, and also useful for debugging, if you port-forward to the machine, since that also will connect on 127.0.0.1.