### PR TITLE
Remove namespace environment variable configuration

### DIFF
--- a/kubernetes/akka-cluster-deployment.yml
+++ b/kubernetes/akka-cluster-deployment.yml
@@ -42,8 +42,4 @@ spec:
         - name: management
           containerPort: 8558
           protocol: TCP
-        env:
-          - name: NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+


### PR DESCRIPTION
No need to configure the NAMESPACE environment variable anymore, when not configured, Akka management reads the namespace from `/var/run/secrets/kubernetes.io/serviceaccount/namespace`.