### PR TITLE
Use Akka management health checks

### DIFF
--- a/kubernetes/akka-cluster-deployment.yml
+++ b/kubernetes/akka-cluster-deployment.yml
@@ -26,9 +26,20 @@ spec:
       - name: akka-cluster-demo
         image: akka-cluster-demo:1.0.2
         imagePullPolicy: Never
+        readinessProbe:
+          httpGet:
+            path: "/ready"
+            port: management
+          periodSeconds: 2
+          failureThreshold: 20
+          initialDelaySeconds: 2
         livenessProbe:
-          tcpSocket:
-            port: 8558
+          httpGet:
+            path: "/alive"
+            port: management
+          periodSeconds: 2
+          failureThreshold: 20
+          initialDelaySeconds: 2
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
Akka management provides health checks, this will ensure, for example, that no requests are routed to a pod until it's joined the cluster.