### PR TITLE
Remove hardcoded namespaces

### DIFF
--- a/kubernetes/akka-cluster-deployment.yml
+++ b/kubernetes/akka-cluster-deployment.yml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: akka-cluster-demo
   name: akka-cluster-demo
-  namespace: akka-cluster-1
 spec:
   replicas: 3
   selector:

--- a/kubernetes/akka-cluster-rolebindging.yml
+++ b/kubernetes/akka-cluster-rolebindging.yml
@@ -2,7 +2,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-reader
-  namespace: akka-cluster-1
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["pods"]
@@ -12,11 +11,9 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: read-pods
-  namespace: akka-cluster-1
 subjects:
-  # Create the default user for the akka-cluster-1 namespace
-  - kind: User
-    name: system:serviceaccount:akka-cluster-1:default
+  - kind: ServiceAccount
+    name: default
 roleRef:
   kind: Role
   name: pod-reader


### PR DESCRIPTION
Generally it's not a good idea to hard code namespaces in yaml specs. This allows the demo specs to be deployed, unmodified, to any namespace, simply by running:

```
kubectl apply -f kubernetes/ -n my-namespace
```