### PR TITLE
Limit heap usage to 128mb

### DIFF
--- a/kubernetes/akka-cluster-deployment.yml
+++ b/kubernetes/akka-cluster-deployment.yml
@@ -43,6 +43,8 @@ spec:
           containerPort: 8558
           protocol: TCP
         env:
+          - name: JAVA_OPTS
+            value: "-Xmx128m -Xms128m"
           - name: NAMESPACE
             valueFrom:
               fieldRef:

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
                                     <exec>
                                         <args>/bin/sh</args>
                                         <args>-c</args>
-                                        <args>java -jar /maven/akka-cluster-openshift.jar</args>
+                                        <args>java $JAVA_OPTS -jar /maven/akka-cluster-openshift.jar</args>
                                     </exec>
                                 </entryPoint>
                                 <assembly>


### PR DESCRIPTION
By default, Java will use a max heap size of 25% of the available system memory. So, let's say you're using n1-standard-4 compute nodes on GCE, system memory available to a container without setting any resource limets will be 15GB, so it's going to default to almost 4GB heaps, about 32x what this app really needs.